### PR TITLE
C++ front end fixes

### DIFF
--- a/src/cpp/cpp_convert_type.cpp
+++ b/src/cpp/cpp_convert_type.cpp
@@ -28,7 +28,7 @@ public:
   unsigned unsigned_cnt, signed_cnt, char_cnt, int_cnt, short_cnt,
            long_cnt, const_cnt, restrict_cnt, constexpr_cnt, volatile_cnt,
            double_cnt, float_cnt, complex_cnt, cpp_bool_cnt, proper_bool_cnt,
-           extern_cnt, wchar_t_cnt, char16_t_cnt, char32_t_cnt,
+           extern_cnt, noreturn_cnt, wchar_t_cnt, char16_t_cnt, char32_t_cnt,
            int8_cnt, int16_cnt, int32_cnt, int64_cnt, ptr32_cnt, ptr64_cnt,
            float128_cnt, int128_cnt;
 
@@ -51,7 +51,7 @@ void cpp_convert_typet::read(const typet &type)
   unsigned_cnt=signed_cnt=char_cnt=int_cnt=short_cnt=
   long_cnt=const_cnt=restrict_cnt=constexpr_cnt=volatile_cnt=
   double_cnt=float_cnt=complex_cnt=cpp_bool_cnt=proper_bool_cnt=
-  extern_cnt=wchar_t_cnt=char16_t_cnt=char32_t_cnt=
+  extern_cnt=noreturn_cnt=wchar_t_cnt=char16_t_cnt=char32_t_cnt=
   int8_cnt=int16_cnt=int32_cnt=int64_cnt=
   ptr32_cnt=ptr64_cnt=float128_cnt=int128_cnt=0;
 
@@ -130,6 +130,10 @@ void cpp_convert_typet::read_rec(const typet &type)
     constexpr_cnt++;
   else if(type.id()==ID_extern)
     extern_cnt++;
+  else if(type.id()==ID_noreturn)
+  {
+    noreturn_cnt++;
+  }
   else if(type.id()==ID_function_type)
   {
     read_function_type(type);

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_declarator_converter.h"
 
-//#define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif
@@ -74,7 +72,7 @@ symbolt &cpp_declarator_convertert::convert(
     scope=&cpp_typecheck.cpp_scopes.current_scope();
 
     // check the declarator-part of the type, in that scope
-    //TODO: if it is a friend declaration we have to type-check it
+    // TODO: if it is a friend declaration we have to type-check it
     //      in our current scope to have access to the correct
     //      template parameters, although the symbol finally resides
     //      in the resolved scope (actually it should be sufficient
@@ -83,7 +81,7 @@ symbolt &cpp_declarator_convertert::convert(
     if(!is_friend)
       cpp_typecheck.typecheck_type(final_type);
   }
-  //TODO: see comment above
+  // TODO: see comment above
   if(is_friend)
     cpp_typecheck.typecheck_type(final_type);
 

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_typecheck.h"
 
-//#define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif
@@ -460,8 +458,8 @@ const symbolt &cpp_typecheckt::instantiate_template(
     const irep_idt& new_symb_id = new_decl.type().get(ID_identifier);
     symbolt &new_symb = symbol_table.lookup(new_symb_id);
 
-    //add template arguments to type in order to retrieve template map
-    //  when typechecking function body
+    // add template arguments to type in order to retrieve template map
+    // when typechecking function body
     new_symb.type.set(ID_C_template, template_type);
     new_symb.type.set(ID_C_template_arguments, specialization_template_args);
 

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -465,7 +465,7 @@ const symbolt &cpp_typecheckt::instantiate_template(
 
 #ifdef DEBUG
     std::cout << "instance symbol: " << new_symb.name << "\n\n";
-    std::cout << "template type: " << template_type << "\n\n";
+    std::cout << "template type: " << template_type.pretty() << "\n\n";
 #endif
 
     return new_symb;

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_typecheck.h"
 
-//#define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif
@@ -905,7 +903,7 @@ void cpp_typecheckt::typecheck_friend_declaration(
   {
 #ifdef DEBUG
     std::cout << "decl: " << sub_it->pretty() << "\n with value "
-	            << sub_it->value().pretty() << '\n';
+              << sub_it->value().pretty() << '\n';
     std::cout << "  scope: " << cpp_scopes.current_scope().prefix << '\n';
 #endif
     // In which scope are we going to typecheck this?

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -902,8 +902,8 @@ void cpp_typecheckt::typecheck_friend_declaration(
   for(auto &sub_it : declaration.declarators())
   {
 #ifdef DEBUG
-    std::cout << "decl: " << sub_it->pretty() << "\n with value "
-              << sub_it->value().pretty() << '\n';
+    std::cout << "decl: " << sub_it.pretty() << "\n with value "
+              << sub_it.value().pretty() << '\n';
     std::cout << "  scope: " << cpp_scopes.current_scope().prefix << '\n';
 #endif
     // In which scope are we going to typecheck this?

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -433,7 +433,7 @@ bool cpp_typecheckt::overloadable(const exprt &expr)
       t=t.subtype();
 
     if(t.id()==ID_struct ||
-       //this might be an incomplete struct (template) here
+       // this might be an incomplete struct (template) here
        t.id()==ID_incomplete_struct ||
        t.id()==ID_union ||
        t.id()==ID_c_enum)
@@ -605,7 +605,7 @@ bool cpp_typecheckt::operator_is_overloaded(exprt &expr)
       // We try and fail silently, maybe conversions will work
       // instead.
 
-      //TODO: need to resolve an incomplete struct (template) here
+      // TODO: need to resolve an incomplete struct (template) here
       // go into scope of first operand
       if(expr.op0().type().id()==ID_symbol &&
          follow(expr.op0().type()).id()==ID_struct)
@@ -2409,7 +2409,7 @@ void cpp_typecheckt::typecheck_method_application(
     const irept &template_type=tag_symbol.type.find(ID_C_template);
     const irept &template_args=tag_symbol.type.find(ID_C_template_arguments);
     template_map.build(static_cast<const template_typet &>(template_type),
-		       static_cast<const cpp_template_args_tct &>(template_args));
+  	       static_cast<const cpp_template_args_tct &>(template_args));
     add_method_body(&method_symbol);
 #ifdef DEBUG
     std::cout << "MAP for " << symbol << ":" << std::endl;

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -31,6 +31,10 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_exception_id.h"
 #include "expr2cpp.h"
 
+#ifdef DEBUG
+#include <iostream>
+#endif
+
 bool cpp_typecheckt::find_parent(
   const symbolt &symb,
   const irep_idt &base_name,

--- a/src/cpp/cpp_typecheck_method_bodies.cpp
+++ b/src/cpp/cpp_typecheck_method_bodies.cpp
@@ -9,8 +9,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 /// \file
 /// C++ Language Type Checking
 
-//#define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif
@@ -72,7 +70,7 @@ void cpp_typecheckt::add_method_body(symbolt *_method_symbol)
     return;
   }
   method_bodies.push_back(method_bodyt(
-			      _method_symbol, template_map, instantiation_stack));
+    _method_symbol, template_map, instantiation_stack));
 
   // Converting a method body might add method bodies for methods
   // that we have already analyzed. Hence, we have to keep track.

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -30,7 +30,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <ansi-c/anonymous_member.h>
 
 #include "cpp_typecheck.h"
-#include "cpp_typecheck_resolve.h"
 #include "cpp_template_type.h"
 #include "cpp_type2name.h"
 #include "cpp_util.h"
@@ -686,9 +685,9 @@ void cpp_typecheck_resolvet::resolve_argument(
   exprt &argument,
   const cpp_typecheck_fargst &fargs)
 {
-  if(argument.id()=="ambiguous") //could come from a template parameter
+  if(argument.id()=="ambiguous") // could come from a template parameter
   {
-    //this must be resolved in the template scope
+    // this must be resolved in the template scope
     cpp_save_scopet save_scope(cpp_typecheck.cpp_scopes);
     cpp_typecheck.cpp_scopes.go_to(*original_scope);
 
@@ -937,7 +936,7 @@ cpp_scopet &cpp_typecheck_resolvet::resolve_scope(
 #ifdef DEBUG
         std::cout << "S: "
                   << cpp_typecheck.cpp_scopes.current_scope().identifier
-                  << std::endl;
+                  << "\n";
         cpp_typecheck.cpp_scopes.current_scope().print(std::cout);
         std::cout << "X: " << id_set.size() <<std::endl;
 #endif

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_typecheck_resolve.h"
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif
@@ -1416,11 +1414,11 @@ exprt cpp_typecheck_resolvet::resolve(
   resolve_scope(cpp_name, base_name, template_args);
 
 #ifdef DEBUG
-  std::cout << "base name: " << base_name << std::endl;
-  std::cout << "template args: " << template_args << std::endl;
-  std::cout << "original-scope: " << original_scope->prefix << std::endl;
+  std::cout << "base name: " << base_name << "\n";
+  std::cout << "template args: " << template_args.pretty() << "\n";
+  std::cout << "original-scope: " << original_scope->prefix << "\n";
   std::cout << "scope: "
-            << cpp_typecheck.cpp_scopes.current_scope().prefix << std::endl;
+            << cpp_typecheck.cpp_scopes.current_scope().prefix << "\n";
 #endif
 
   const source_locationt &source_location=cpp_name.source_location();

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -479,7 +479,12 @@ void Parser::merge_types(const typet &src, typet &dest)
       dest=tmp;
     }
 
-    dest.copy_to_subtypes(src);
+    // the end of the subtypes container needs to stay the same,
+    // since several analysis functions traverse via the end for
+    // merged_types
+    typet::subtypest &sub=dest.subtypes();
+    sub.emplace(sub.begin(), src);
+    POSTCONDITION(!dest.subtypes().empty());
   }
 }
 
@@ -3200,12 +3205,9 @@ bool Parser::optPtrOperator(typet &ptrs)
       cv.make_nil();
       optCvQualify(cv); // the qualifier is for the pointer
       if(cv.is_not_nil())
-      {
-        merge_types(op, cv);
-        t_list.push_back(cv);
-      }
-      else
-        t_list.push_back(op);
+        merge_types(cv, op);
+
+      t_list.push_back(op);
     }
     else if(t=='^')
     {
@@ -3219,12 +3221,9 @@ bool Parser::optPtrOperator(typet &ptrs)
       cv.make_nil();
       optCvQualify(cv); // the qualifier is for the pointer
       if(cv.is_not_nil())
-      {
-        merge_types(op, cv);
-        t_list.push_back(cv);
-      }
-      else
-        t_list.push_back(op);
+        merge_types(cv, op);
+
+      t_list.push_back(op);
     }
     else if(isPtrToMember(0))
     {

--- a/src/symex/path_search.cpp
+++ b/src/symex/path_search.cpp
@@ -293,7 +293,7 @@ bool path_searcht::drop_state(const statet &state)
     return true;
 
   // unwinding limit -- loops
-  if(unwind_limit!=std::numeric_limits<unsigned>::max() && 
+  if(unwind_limit!=std::numeric_limits<unsigned>::max() &&
      pc->is_backwards_goto())
   {
     bool stop=false;


### PR DESCRIPTION
These changes fix some of the linter issues that were reported for the original pull request. However, new ones will arise, because now assert() has been deprecated and there are many asserts in the files touched by the PR.
The changes also fix a failure to compile with -DDEBUG. Some of the code inside #ifdef DEBUG ... #endif  did not compile anymore.
Most importantly, the order in which types are merged has been reversed. Now merge_types(x, y) will make y into a merged_type with (x, y) as subtypes *in that order*. This change fixes the regression failures in the cpp tests and regression is now passing. 