### PR TITLE
C++ front end fixes: prevent regression failures on windows, implement style improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,6 +86,8 @@ test_script:
     rmdir /s /q cpp\Decltype1
     rmdir /s /q cpp\Decltype2
     rmdir /s /q cpp\Function_Overloading1
+    rmdir /s /q cpp\Function_Overloading2
+    rmdir /s /q cpp\Function_Overloading3
     rmdir /s /q cpp\enum2
     rmdir /s /q cpp\enum7
     rmdir /s /q cpp\enum8

--- a/regression/cpp/Resolver10/main.cpp
+++ b/regression/cpp/Resolver10/main.cpp
@@ -1,5 +1,3 @@
-#include <cassert>
-
 struct A
 {
   int i;

--- a/regression/cpp/Resolver11/main.cpp
+++ b/regression/cpp/Resolver11/main.cpp
@@ -1,5 +1,3 @@
-#include <cassert>
-
 struct A
 {
   bool func() { return false; }

--- a/regression/cpp/Template_Parameters1/main.cpp
+++ b/regression/cpp/Template_Parameters1/main.cpp
@@ -1,5 +1,3 @@
-#include <cassert>
-
 // V depends on Ty
 template<typename Ty, Ty V>
 class T

--- a/src/cpp/cpp_scope.cpp
+++ b/src/cpp/cpp_scope.cpp
@@ -142,8 +142,7 @@ void cpp_scopet::lookup(
     other_scope.lookup(base_name, QUALIFIED, id_class, id_set);
   }
 
-  if(!id_set.empty() &&
-     id_class!=id_classt::TEMPLATE)
+  if(!id_set.empty() && id_class!=id_classt::TEMPLATE)
     return; // done, upwards scopes are hidden
 
   // secondary scopes

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -333,8 +333,11 @@ bool cpp_typecheckt::contains_cpp_name(const exprt &expr)
 {
   if(expr.id()==ID_cpp_name)
     return true;
-  forall_operands(it, expr)
-    if(contains_cpp_name(*it))
+
+  for(const exprt &op : expr.operands())
+  {
+    if(contains_cpp_name(op))
       return true;
+  }
   return false;
 }

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -6,7 +6,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 \********************************************************************/
 
-
 /// \file
 /// C++ Language Type Checking
 

--- a/src/cpp/cpp_typecheck_method_bodies.cpp
+++ b/src/cpp/cpp_typecheck_method_bodies.cpp
@@ -40,15 +40,12 @@ void cpp_typecheckt::typecheck_method_bodies()
       continue;
 
 #ifdef DEBUG
-  std::cout << "convert_method_body: " << method_symbol.name << std::endl;
-  std::cout << "  is_not_nil: " << body.is_not_nil() << std::endl;
-  std::cout << "  !is_zero: " << (!body.is_zero()) << std::endl;
+    std::cout << "convert_method_body: " << method_symbol.name << "\n";
+    std::cout << "  is_not_nil: " << body.is_not_nil() << "\n";
+    std::cout << "  !is_zero: " << (!body.is_zero()) << "\n";
 #endif
-    if(body.is_not_nil() &&
-       !body.is_zero())
-    {
+    if(body.is_not_nil() && !body.is_zero())
       convert_function(method_symbol);
-    }
   }
 
   old_instantiation_stack.swap(instantiation_stack);
@@ -57,22 +54,16 @@ void cpp_typecheckt::typecheck_method_bodies()
 void cpp_typecheckt::add_method_body(symbolt *_method_symbol)
 {
 #ifdef DEBUG
-  std::cout << "add_method_body: " << _method_symbol->name << std::endl;
+  std::cout << "add_method_body: " << _method_symbol->name << "\n";
 #endif
-
-  // We have to prevent the same method to be added multiple times
-  //   otherwise we get duplicated symbol prefixes
-  if(methods_seen.find(_method_symbol->name) != methods_seen.end())
-  {
+  // Converting a method body might add method bodies for methods that we have
+  // already analyzed. Adding the same method more than once causes duplicated
+  // symbol prefixes, therefore we have to keep track.
+  if(methods_seen.insert(_method_symbol->name).second)
+    method_bodies.push_back(method_bodyt(
+      _method_symbol, template_map, instantiation_stack));
 #ifdef DEBUG
-    std::cout << "  already exists" << std::endl;
+  else
+    std::cout << "  already exists" << "\n";
 #endif
-    return;
-  }
-  method_bodies.push_back(method_bodyt(
-    _method_symbol, template_map, instantiation_stack));
-
-  // Converting a method body might add method bodies for methods
-  // that we have already analyzed. Hence, we have to keep track.
-  methods_seen.insert(_method_symbol->name);
 }

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -500,9 +500,9 @@ void cpp_typecheck_resolvet::disambiguate_functions(
     for(resolve_identifierst::const_iterator
         it1=old_identifiers.begin();
         it1!=old_identifiers.end();
-        it1++)
+        ++it1)
     {
-#if 0
+#ifdef DEBUG
       std::cout << "I1: " << it1->get(ID_identifier) << std::endl;
 #endif
 

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -480,11 +480,10 @@ void Parser::merge_types(const typet &src, typet &dest)
       dest=tmp;
     }
 
-    // the end of the subtypes container needs to stay the same,
-    // since several analysis functions traverse via the end for
-    // merged_types
+    // the end of the subtypes container needs to stay the same since several
+    // analysis functions traverse via the end for merged_types
     typet::subtypest &sub=dest.subtypes();
-    sub.emplace(sub.begin(), src);
+    sub.insert(sub.begin(), src);
     POSTCONDITION(!dest.subtypes().empty());
   }
 }


### PR DESCRIPTION
CI failures of regression tests in the cpp directory are avoided by not running tests on windows (`Function_Overloading{2,3}`), or by removing system headers from regression sources (`Resolver{10,11}, Template_Parameters1`). I tested this on windows locally and it worked.
A second commit implements style suggestions made by @smowton.

 
 