### PR TITLE
Field sensitivity fixes

### DIFF
--- a/regression/cbmc/Array_Propagation1/test.desc
+++ b/regression/cbmc/Array_Propagation1/test.desc
@@ -4,6 +4,6 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
-(Starting CEGAR Loop|VCC\(s\), 0 remaining after simplification$)
+(Starting CEGAR Loop|VCC\(s\), 1 remaining after simplification$)
 --
 ^warning: ignoring

--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -46,7 +46,7 @@ void field_sensitivityt::apply(const namespacet &ns, exprt &expr, bool write)
   {
     simplify(expr, ns);
   }
-  else if(write && expr.id() == ID_member)
+  else if(expr.id() == ID_member)
   {
     member_exprt &member = to_member_expr(expr);
 
@@ -64,7 +64,7 @@ void field_sensitivityt::apply(const namespacet &ns, exprt &expr, bool write)
       expr.swap(tmp);
     }
   }
-  else if(write && expr.id() == ID_index)
+  else if(expr.id() == ID_index)
   {
     index_exprt &index = to_index_expr(expr);
     simplify(index.index(), ns);

--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -167,14 +167,16 @@ void field_sensitivityt::field_assignments(
   const namespacet &ns,
   goto_symex_statet &state,
   symex_targett &target,
-  const exprt &lhs)
+  const exprt &lhs,
+  bool allow_pointer_unsoundness)
 {
   exprt lhs_fs = lhs;
   apply(ns, lhs_fs, false, state);
 
   bool do_apply_bak = do_apply;
   do_apply = false;
-  field_assignments_rec(ns, state, target, lhs_fs, lhs);
+  field_assignments_rec(
+    ns, state, target, lhs_fs, lhs, allow_pointer_unsoundness);
   do_apply = do_apply_bak;
 }
 
@@ -183,7 +185,8 @@ void field_sensitivityt::field_assignments_rec(
   goto_symex_statet &state,
   symex_targett &target,
   const exprt &lhs_fs,
-  const exprt &lhs)
+  const exprt &lhs,
+  bool allow_pointer_unsoundness)
 {
   const typet &followed_type = ns.follow(lhs.type());
 
@@ -197,7 +200,8 @@ void field_sensitivityt::field_assignments_rec(
     simplify(ssa_rhs, ns);
 
     ssa_exprt ssa_lhs = to_ssa_expr(lhs_fs);
-    state.assignment(ssa_lhs, ssa_rhs, ns, true, true);
+    state.assignment(
+      ssa_lhs, ssa_rhs, ns, true, true, allow_pointer_unsoundness);
 
     // do the assignment
     target.assignment(
@@ -225,7 +229,8 @@ void field_sensitivityt::field_assignments_rec(
       const member_exprt member_rhs(lhs, comp.get_name(), comp.type());
       const exprt &member_lhs = lhs_fs.operands()[number];
 
-      field_assignments_rec(ns, state, target, member_lhs, member_rhs);
+      field_assignments_rec(
+        ns, state, target, member_lhs, member_rhs, allow_pointer_unsoundness);
       ++number;
     }
   }
@@ -243,7 +248,8 @@ void field_sensitivityt::field_assignments_rec(
       const index_exprt index_rhs(lhs, from_integer(i, index_type()));
       const exprt &index_lhs = lhs_fs.operands()[i];
 
-      field_assignments_rec(ns, state, target, index_lhs, index_rhs);
+      field_assignments_rec(
+        ns, state, target, index_lhs, index_rhs, allow_pointer_unsoundness);
     }
   }
   */
@@ -255,7 +261,8 @@ void field_sensitivityt::field_assignments_rec(
     exprt::operandst::const_iterator fs_it = lhs_fs.operands().begin();
     for(const exprt &op : lhs.operands())
     {
-      field_assignments_rec(ns, state, target, *fs_it, op);
+      field_assignments_rec(
+        ns, state, target, *fs_it, op, allow_pointer_unsoundness);
       ++fs_it;
     }
   }

--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -40,12 +40,14 @@ void field_sensitivityt::apply(const namespacet &ns, exprt &expr, bool write)
   {
     simplify(expr, ns);
   }
+  /*
   else if(
     !write && expr.id() == ID_index &&
     to_index_expr(expr).array().id() == ID_array)
   {
     simplify(expr, ns);
   }
+  */
   else if(expr.id() == ID_member)
   {
     member_exprt &member = to_member_expr(expr);
@@ -64,6 +66,7 @@ void field_sensitivityt::apply(const namespacet &ns, exprt &expr, bool write)
       expr.swap(tmp);
     }
   }
+  /*
   else if(expr.id() == ID_index)
   {
     index_exprt &index = to_index_expr(expr);
@@ -84,6 +87,7 @@ void field_sensitivityt::apply(const namespacet &ns, exprt &expr, bool write)
       expr.swap(tmp);
     }
   }
+  */
 #endif
 }
 
@@ -115,6 +119,7 @@ exprt field_sensitivityt::get_fields(
 
     return result;
   }
+  /*
   else if(
     followed_type.id() == ID_array &&
     to_array_type(followed_type).size().id() == ID_constant)
@@ -138,6 +143,7 @@ exprt field_sensitivityt::get_fields(
 
     return result;
   }
+  */
   else
 #endif
     return ssa_expr;
@@ -209,6 +215,7 @@ void field_sensitivityt::field_assignments_rec(
       ++number;
     }
   }
+  /*
   else if(followed_type.id() == ID_array)
   {
     const array_typet &type = to_array_type(followed_type);
@@ -225,6 +232,7 @@ void field_sensitivityt::field_assignments_rec(
       field_assignments_rec(ns, state, target, index_lhs, index_rhs);
     }
   }
+  */
   else if(lhs_fs.has_operands())
   {
     PRECONDITION(

--- a/src/goto-symex/field_sensitivity.h
+++ b/src/goto-symex/field_sensitivity.h
@@ -54,7 +54,8 @@ public:
     const namespacet &ns,
     goto_symex_statet &state,
     symex_targett &target,
-    const exprt &lhs);
+    const exprt &lhs,
+    bool allow_pointer_unsoundness);
 
   /// Determine whether \p expr would translate to a single field-sensitive SSA
   /// expression.
@@ -80,7 +81,8 @@ private:
     goto_symex_statet &state,
     symex_targett &target,
     const exprt &lhs_fs,
-    const exprt &lhs);
+    const exprt &lhs,
+    bool allow_pointer_unsoundness);
 };
 
 #endif // CPROVER_GOTO_SYMEX_FIELD_SENSITIVITY_H

--- a/src/goto-symex/field_sensitivity.h
+++ b/src/goto-symex/field_sensitivity.h
@@ -31,14 +31,16 @@ public:
   /// \param expr: an expression to be (recursively) transformed - this
   /// parameter is both input and output.
   /// \param write: set to true if the expression is to be used as an lvalue.
-  static void apply(const namespacet &ns, exprt &expr, bool write);
+  static void apply(
+    const namespacet &ns, exprt &expr, bool write, goto_symex_statet &state);
 
   /// Compute an expression representing the individual components of a
   /// field-sensitive SSA representation of \p ssa_expr.
   /// \param ns: a namespace to resolve type symbols/tag types
   /// \param expr: the expression to evaluate
   /// \return Expanded expression
-  static exprt get_fields(const namespacet &ns, const ssa_exprt &ssa_expr);
+  static exprt get_fields(
+    const namespacet &ns, const ssa_exprt &ssa_expr, goto_symex_statet &state);
 
   /// Assign to the individual fields of a non-expanded symbol \p lhs. This is
   /// required whenever prior steps have updated the full object rather than
@@ -60,7 +62,8 @@ public:
   /// \param expr: the expression to evaluate
   /// \return True, if and only if, \p expr would be a single field-sensitive
   /// SSA expression.
-  static bool is_indivisible(const namespacet &ns, const ssa_exprt &expr);
+  static bool is_indivisible(
+    const namespacet &ns, const ssa_exprt &expr, goto_symex_statet &state);
 
 private:
   /// Assign to the individual fields \p lhs_fs of a non-expanded symbol \p lhs.

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -371,7 +371,19 @@ void goto_symex_statet::rename(
     }
 
     if(level == L2)
+    {
       field_sensitivityt::apply(ns, expr, false);
+
+      // This might have introduced a new SSA expression we should look up in
+      // the constant propagator:
+      if(is_ssa_expr(expr))
+      {
+        auto const_it =
+          propagation.values.find(to_ssa_expr(expr).get_l1_object_identifier());
+        if(const_it != propagation.values.end())
+          expr = const_it->second;
+      }
+    }
   }
 }
 

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -372,7 +372,7 @@ void goto_symex_statet::rename(
 
     if(level == L2)
     {
-      field_sensitivityt::apply(ns, expr, false);
+      field_sensitivityt::apply(ns, expr, false, *this);
 
       // This might have introduced a new SSA expression we should look up in
       // the constant propagator:
@@ -404,7 +404,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
     return false;
 
   // is it an indivisible object being accessed?
-  if(!field_sensitivityt::is_indivisible(ns, expr))
+  if(!field_sensitivityt::is_indivisible(ns, expr, *this))
     return false;
 
   ssa_exprt ssa_l1=expr;
@@ -551,7 +551,7 @@ bool goto_symex_statet::l2_thread_write_encoding(
     return false; // not shared
 
   // is it an indivisible object being accessed?
-  if(!field_sensitivityt::is_indivisible(ns, expr))
+  if(!field_sensitivityt::is_indivisible(ns, expr, *this))
     return false;
 
   // see whether we are within an atomic section

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -379,8 +379,8 @@ void goto_symex_statet::rename(
       if(is_ssa_expr(expr))
       {
         auto const_it =
-          propagation.values.find(to_ssa_expr(expr).get_l1_object_identifier());
-        if(const_it != propagation.values.end())
+          propagation.find(to_ssa_expr(expr).get_l1_object_identifier());
+        if(const_it != propagation.end())
           expr = const_it->second;
       }
     }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -306,7 +306,7 @@ void goto_symext::symex_assign_symbol(
         to_member_designator(d).get_component_name(),
         u.new_value().type());
 
-    field_sensitivityt::apply(ns, fs_lhs, true);
+    field_sensitivityt::apply(ns, fs_lhs, true, assign);
 
     if(fs_lhs.id() != ID_symbol)
       break;
@@ -327,7 +327,7 @@ void goto_symext::symex_assign_symbol(
       fs_lhs = member_exprt(
         lhs_mod, w.where().get(ID_component_name), w.new_value().type());
 
-    field_sensitivityt::apply(ns, fs_lhs, true);
+    field_sensitivityt::apply(ns, fs_lhs, true, state);
 
     if(fs_lhs.id() != ID_symbol)
       break;

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -385,7 +385,8 @@ void goto_symext::symex_assign_symbol(
     state.source,
     assignment_type);
 
-  field_sensitivityt::field_assignments(ns, state, target, lhs_mod);
+  field_sensitivityt::field_assignments(
+    ns, state, target, lhs_mod, symex_config.allow_pointer_unsoundness);
 
   // If we just assigned a symbol representing a component of a composite object
   // (for example, symbol "some_struct.field#1", which represents part of the

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -386,6 +386,24 @@ void goto_symext::symex_assign_symbol(
     assignment_type);
 
   field_sensitivityt::field_assignments(ns, state, target, lhs_mod);
+
+  // If we just assigned a symbol representing a component of a composite object
+  // (for example, symbol "some_struct.field#1", which represents part of the
+  // symbol "some_struct"), then invalidate "some_struct" in the constant
+  // propagator, as it's now out of date. On future reference we should
+  // reconstruct it from fields using field_sensitivityt::apply.
+  if(ssa_lhs.get_original_expr().id() == ID_member)
+  {
+    ssa_exprt underlying_composite = ssa_lhs;
+    exprt underlying_object = underlying_composite.get_original_expr();
+    while(underlying_object.id() == ID_member)
+      underlying_object = underlying_object.op0();
+    underlying_composite.set_expression(underlying_object);
+
+    // The constant propagator is indexed by L1 names:
+    state.rename(underlying_composite, ns, goto_symex_statet::L1);
+    state.propagation.erase(underlying_composite.get_l1_object_identifier());
+  }
 }
 
 void goto_symext::symex_assign_typecast(

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -56,7 +56,7 @@ void goto_symext::symex_dead(statet &state)
     const irep_idt &l1_identifier = ssa_lhs.get_identifier();
 
     // prevent propagation
-    state.propagation.remove(l1_identifier);
+    state.propagation.erase(l1_identifier);
 
     // TODO: not sure why the rest below is necessary
     // L2 renaming

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -46,7 +46,7 @@ void goto_symext::symex_dead(statet &state)
     state.value_set.assign(ssa, rhs, ns, true, false);
   }
 
-  const exprt l2_fields = field_sensitivityt::get_fields(ns, ssa);
+  const exprt l2_fields = field_sensitivityt::get_fields(ns, ssa, state);
   std::set<exprt> l2_fields_set;
   find_symbols(l2_fields, l2_fields_set);
 

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -63,17 +63,5 @@ void goto_symext::symex_dead(statet &state)
     auto level2_it = state.level2.current_names.find(l1_identifier);
     if(level2_it != state.level2.current_names.end())
       symex_renaming_levelt::increase_counter(level2_it);
-
-    const bool record_events = state.record_events;
-    state.record_events = false;
-    state.rename(ssa_lhs, ns);
-    state.record_events = record_events;
-
-    if(
-      state.dirty(ssa_lhs.get_object_name()) && state.atomic_section_id == 0)
-    {
-      target.shared_write(
-        state.guard.as_expr(), ssa_lhs, state.atomic_section_id, state.source);
-    }
   }
 }

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -387,7 +387,7 @@ void goto_symext::dereference(
   // symbols whose address is taken.
   PRECONDITION(!state.call_stack().empty());
   state.rename(expr, ns, goto_symex_statet::L1);
-  field_sensitivityt::apply(ns, expr, write);
+  field_sensitivityt::apply(ns, expr, write, state);
 #if 0
   rename_l1_reads_l2(expr, state, ns, write);
   // really, we need to use another dereferencing implementation,
@@ -400,5 +400,5 @@ void goto_symext::dereference(
   // dereferencing may introduce new symbol_exprt
   // (like __CPROVER_memory)
   state.rename(expr, ns, goto_symex_statet::L1);
-  field_sensitivityt::apply(ns, expr, write);
+  field_sensitivityt::apply(ns, expr, write, state);
 }

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -404,5 +404,14 @@ void goto_symext::dereference(
   // dereferencing may introduce new symbol_exprt
   // (like __CPROVER_memory)
   state.rename(expr, ns, goto_symex_statet::L1);
+
+  // dereferencing is likely to introduce new member-of-if constructs --
+  // for example, "x->field" may have become "(x == &o1 ? o1 : o2).field"
+  // Simplify (which converts that to (x == &o1 ? o1.field : o2.field)) before
+  // applying field sensitivity, which can turn such field-of-symbol expressions
+  // into atomic SSA expressions, but would have to rewrite all of 'o1'
+  // otherwise.
+  do_simplify(expr);
+
   field_sensitivityt::apply(ns, expr, write, state);
 }

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -300,6 +300,10 @@ void goto_symext::dereference_rec(
 
     // this may yield a new auto-object
     trigger_auto_object(expr, state);
+
+    // ...and may have introduced a member-of-symbol construct with a
+    // corresponding SSA symbol:
+    field_sensitivityt::apply(ns, expr, write, state);
   }
   else if(expr.id()==ID_index &&
           to_index_expr(expr).array().id()==ID_member &&

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -435,8 +435,8 @@ static void merge_names(
   }
 
   // field sensitivity: only merge on individual fields
-  if(!field_sensitivityt::is_indivisible(ns, *it))
-    continue;
+  if(!field_sensitivityt::is_indivisible(ns, ssa))
+    return;
 
   // shared variables are renamed on every access anyway, we don't need to
   // merge anything

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -435,7 +435,7 @@ static void merge_names(
   }
 
   // field sensitivity: only merge on individual fields
-  if(!field_sensitivityt::is_indivisible(ns, ssa))
+  if(!field_sensitivityt::is_indivisible(ns, ssa, dest_state))
     return;
 
   // shared variables are renamed on every access anyway, we don't need to

--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -32,6 +32,7 @@ static void build_ssa_identifier_rec(
     build_ssa_identifier_rec(member.struct_op(), l0, l1, l2, os, l1_object_os);
 
     os << '.' << member.get_component_name();
+    l1_object_os << '.' << member.get_component_name();
   }
   else if(expr.id()==ID_index)
   {
@@ -41,6 +42,7 @@ static void build_ssa_identifier_rec(
 
     const mp_integer idx = numeric_cast_v<mp_integer>(index.index());
     os << '[' << idx << ']';
+    l1_object_os << '[' << idx << ']';
   }
   else if(expr.id()==ID_symbol)
   {

--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -31,8 +31,8 @@ static void build_ssa_identifier_rec(
 
     build_ssa_identifier_rec(member.struct_op(), l0, l1, l2, os, l1_object_os);
 
-    os << '.' << member.get_component_name();
-    l1_object_os << '.' << member.get_component_name();
+    os << ".." << member.get_component_name();
+    l1_object_os << ".." << member.get_component_name();
   }
   else if(expr.id()==ID_index)
   {


### PR DESCRIPTION
I think these are mostly straightforward bugfixes to the existing work without changing the design (design comments will go on the root PR). Three exceptions:

1. Use "[[]]" and ".." for array and field separators. While we don't have to choose these particular symbols, I think we should do something like this, both to help people read the difference between an atomic symbol and a member-of or index-of-composite operation, and to avoid code accidentally working because the stringified version of the two expressions happens to coincide, as for example in `value_sett`'s LHS, which uses string keys of the form `symbol` or `symbol.component`.

2. "Don't treat a dead instruction as a shared write" reverts additional functionality added by the root PR on top of current develop's treatment of `code_deadt`, which does not register a write op. I think adding that treatment is sensible, as the idea that deallocated memory can be trashed and that waiting for that to happen can be a route to an exploit is important, but I think this is orthogonal to field-sensitivity and doesn't belong in this PR.

3. The "non equal types" warning now seen in some string tests may be this work exposing a latent bug in the Java frontend (in the cases I've checked, it's complaning about a statement "some_java_lang_class->enumConstantDirectory = null", where the LHS has a qualified generic type and the RHS does not. It may previously have been getting away with this by virtue of the inequality hiding behind a symbol type -- but this should be verified, and then ideally fixed upstream so we can drop this commit.