### PR TITLE
Field sensitivity improvements round 2

### DIFF
--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -271,9 +271,19 @@ void field_sensitivityt::field_assignments_rec(
   }
 }
 
-bool field_sensitivityt::is_divisible(
-  goto_symex_statet &state,
-  const ssa_exprt &expr) const
+bool field_sensitivityt::is_divisible(const ssa_exprt &expr)
 {
-  return expr != get_fields(state, expr);
+  if(expr.type().id() == ID_struct || expr.type().id() == ID_struct_tag)
+    return true;
+
+#ifdef ENABLE_ARRAY_FIELD_SENSITIVITY
+  if(
+    expr.type().id() == ID_array &&
+    to_array_type(expr.type()).size().id() == ID_constant)
+  {
+    return true;
+  }
+#endif
+
+  return false;
 }

--- a/src/goto-symex/field_sensitivity.h
+++ b/src/goto-symex/field_sensitivity.h
@@ -63,11 +63,10 @@ public:
   /// (returns false) or a composite object made of several SSA expressions as
   /// components (such as a struct with each member becoming an individual SSA
   /// expression, return true in this case).
-  /// \param state: symbolic execution state
   /// \param expr: the expression to evaluate
   /// \return False, if and only if, \p expr would be a single field-sensitive
   /// SSA expression.
-  bool is_divisible(goto_symex_statet &state, const ssa_exprt &expr) const;
+  static bool is_divisible(const ssa_exprt &expr);
 
 private:
   const namespacet &ns;

--- a/src/goto-symex/field_sensitivity.h
+++ b/src/goto-symex/field_sensitivity.h
@@ -34,7 +34,18 @@ public:
   /// index.
   /// \param state: symbolic execution state
   /// \param lhs: non-expanded symbol
-  void field_assignments(goto_symex_statet &state, const exprt &lhs);
+  void field_assignments(goto_symex_statet &state, const ssa_exprt &lhs);
+
+  /// If `is_divisible(lhs)` then assign indivisible symbols (fields or array
+  /// indices) from the divisible symbol and erase the divisible symbol from
+  /// \p state.
+  /// \param state: symbolic execution state
+  /// \param lhs: non-expanded symbol
+  /// \param ns: symex's working namespace
+  void post_process_assignment(
+    goto_symex_statet &state,
+    const ssa_exprt &lhs,
+    const namespacet &ns);
 
   /// Turn an expression \p expr into a field-sensitive SSA expression.
   /// Field-sensitive SSA expressions have individual symbols for each

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -211,9 +211,9 @@ protected:
   void initialize_auto_object(const exprt &, statet &);
   void process_array_expr(statet &, exprt &);
   exprt make_auto_object(const typet &, statet &);
-  virtual void dereference(exprt &, statet &);
+  virtual void dereference(exprt &, statet &, bool write);
 
-  void dereference_rec(exprt &, statet &);
+  void dereference_rec(exprt &, statet &, bool write);
   exprt address_arithmetic(
     const exprt &,
     statet &,

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -358,19 +358,7 @@ void goto_symex_statet::rename(
       "if_exprt");
 
     if(level == L2)
-    {
       field_sensitivity.apply(*this, expr, false);
-
-      // This might have introduced a new SSA expression we should look up in
-      // the constant propagator:
-      if(is_ssa_expr(expr))
-      {
-        auto const_it =
-          propagation.find(to_ssa_expr(expr).get_l1_object_identifier());
-        if(const_it != propagation.end())
-          expr = const_it->second;
-      }
-    }
   }
 }
 

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -190,7 +190,7 @@ void goto_symex_statet::assignment(
   set_l2_indices(lhs, ns);
 
   // in case we happen to be multi-threaded, record the memory access
-  bool is_shared = l2_thread_write_encoding(lhs, ns, field_sensitivity);
+  bool is_shared = l2_thread_write_encoding(lhs, ns);
 
   if(run_validation_checks)
   {
@@ -394,7 +394,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
   }
 
   // only continue if an indivisible object is being accessed
-  if(field_sensitivity.is_divisible(*this, expr))
+  if(field_sensitivityt::is_divisible(expr))
     return false;
 
   ssa_exprt ssa_l1=expr;
@@ -521,8 +521,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
 /// thread encoding
 bool goto_symex_statet::l2_thread_write_encoding(
   const ssa_exprt &expr,
-  const namespacet &ns,
-  const field_sensitivityt &field_sensitivity)
+  const namespacet &ns)
 {
   if(!record_events)
     return false;
@@ -537,7 +536,7 @@ bool goto_symex_statet::l2_thread_write_encoding(
   }
 
   // only continue if an indivisible object is being accessed
-  if(field_sensitivity.is_divisible(*this, expr))
+  if(field_sensitivityt::is_divisible(expr))
     return false;
 
   // see whether we are within an atomic section

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -293,10 +293,7 @@ public:
     ssa_exprt &expr,
     const namespacet &ns,
     const field_sensitivityt &field_sensitivity);
-  bool l2_thread_write_encoding(
-    const ssa_exprt &expr,
-    const namespacet &ns,
-    const field_sensitivityt &field_sensitivity);
+  bool l2_thread_write_encoding(const ssa_exprt &expr, const namespacet &ns);
 
   bool record_events;
 

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -311,8 +311,6 @@ static void shift_indexed_access_to_lhs(
       lhs_mod = to_ssa_expr(byte_extract);
     }
   }
-
-  rewrite_with_to_field_symbols(state, ssa_rhs, lhs_mod, field_sensitivity);
 }
 
 void goto_symext::symex_assign_symbol(
@@ -336,8 +334,15 @@ void goto_symext::symex_assign_symbol(
 
   ssa_exprt lhs_mod = lhs;
 
+  // Note the following two calls are specifically required for
+  // field-sensitivity. For example, with-expressions, which may have just been
+  // introduced by symex_assign_struct_member, are transformed into member
+  // expressions on the LHS. If we add an option to disable field-sensitivity
+  // in the future these should be omitted.
   shift_indexed_access_to_lhs(
     state, ssa_rhs, lhs_mod, ns, field_sensitivity, symex_config.simplify_opt);
+
+  rewrite_with_to_field_symbols(state, ssa_rhs, lhs_mod, field_sensitivity);
 
   do_simplify(ssa_rhs);
 

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -385,26 +385,7 @@ void goto_symext::symex_assign_symbol(
     state.source,
     assignment_type);
 
-  field_sensitivity.field_assignments(state, lhs_mod);
-
-  // If we just assigned a symbol representing a component of a composite object
-  // (for example, symbol "some_struct.field#1", which represents part of the
-  // symbol "some_struct"), then invalidate "some_struct" in the constant
-  // propagator, as it's now out of date. On future reference we should
-  // reconstruct it from fields using field_sensitivityt::apply.
-  if(ssa_lhs.get_original_expr().id() == ID_member)
-  {
-    ssa_exprt underlying_composite = ssa_lhs;
-    exprt underlying_object = underlying_composite.get_original_expr();
-    while(underlying_object.id() == ID_member)
-      underlying_object = underlying_object.op0();
-    underlying_composite.set_expression(underlying_object);
-
-    // The constant propagator is indexed by L1 names:
-    state.rename(
-      underlying_composite, ns, field_sensitivity, goto_symex_statet::L1);
-    state.propagation.erase(underlying_composite.get_l1_object_identifier());
-  }
+  field_sensitivity.post_process_assignment(state, lhs_mod, ns);
 }
 
 void goto_symext::symex_assign_typecast(

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -175,7 +175,7 @@ void goto_symext::clean_expr(
   const bool write)
 {
   replace_nondet(expr, path_storage.build_symex_nondet);
-  dereference(expr, state);
+  dereference(expr, state, write);
 
   // make sure all remaining byte extract operations use the root
   // object to avoid nesting of with/update and byte_update when on

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -72,7 +72,7 @@ exprt goto_symext::address_arithmetic(
 
     // there could be further dereferencing in the offset
     exprt offset=be.offset();
-    dereference_rec(offset, state);
+    dereference_rec(offset, state, false);
 
     result=plus_exprt(result, offset);
 
@@ -108,14 +108,14 @@ exprt goto_symext::address_arithmetic(
     // just grab the pointer, but be wary of further dereferencing
     // in the pointer itself
     result=to_dereference_expr(expr).pointer();
-    dereference_rec(result, state);
+    dereference_rec(result, state, false);
   }
   else if(expr.id()==ID_if)
   {
     if_exprt if_expr=to_if_expr(expr);
 
     // the condition is not an address
-    dereference_rec(if_expr.cond(), state);
+    dereference_rec(if_expr.cond(), state, false);
 
     // recursive call
     if_expr.true_case() =
@@ -132,7 +132,7 @@ exprt goto_symext::address_arithmetic(
   {
     // give up, just dereference
     result=expr;
-    dereference_rec(result, state);
+    dereference_rec(result, state, false);
 
     // turn &array into &array[0]
     if(result.type().id() == ID_array && !keep_array)
@@ -199,7 +199,7 @@ exprt goto_symext::address_arithmetic(
 /// such as `&struct.flexible_array[0]` (see inline comments in code).
 /// For full details of this method's pointer replacement and potential side-
 /// effects see \ref goto_symext::dereference
-void goto_symext::dereference_rec(exprt &expr, statet &state)
+void goto_symext::dereference_rec(exprt &expr, statet &state, bool write)
 {
   if(expr.id()==ID_dereference)
   {
@@ -223,7 +223,7 @@ void goto_symext::dereference_rec(exprt &expr, statet &state)
     tmp1.swap(to_dereference_expr(expr).pointer());
 
     // first make sure there are no dereferences in there
-    dereference_rec(tmp1, state);
+    dereference_rec(tmp1, state, false);
 
     // we need to set up some elaborate call-backs
     symex_dereference_statet symex_dereference_state(
@@ -267,7 +267,7 @@ void goto_symext::dereference_rec(exprt &expr, statet &state)
     tmp.add_source_location()=expr.source_location();
 
     // recursive call
-    dereference_rec(tmp, state);
+    dereference_rec(tmp, state, write);
 
     expr.swap(tmp);
   }
@@ -306,17 +306,17 @@ void goto_symext::dereference_rec(exprt &expr, statet &state)
             to_address_of_expr(tc_op).object(),
             from_integer(0, index_type())));
 
-      dereference_rec(expr, state);
+      dereference_rec(expr, state, write);
     }
     else
     {
-      dereference_rec(tc_op, state);
+      dereference_rec(tc_op, state, write);
     }
   }
   else
   {
     Forall_operands(it, expr)
-      dereference_rec(*it, state);
+      dereference_rec(*it, state, write);
   }
 }
 
@@ -357,7 +357,7 @@ void goto_symext::dereference_rec(exprt &expr, statet &state)
 ///    dereferenced. If new objects are created by this mechanism then
 ///    state will be altered (by `symex_assign`) to initialise them.
 ///    See \ref auto_objects.cpp for details.
-void goto_symext::dereference(exprt &expr, statet &state)
+void goto_symext::dereference(exprt &expr, statet &state, bool write)
 {
   // The expression needs to be renamed to level 1
   // in order to distinguish addresses of local variables
@@ -368,7 +368,7 @@ void goto_symext::dereference(exprt &expr, statet &state)
   field_sensitivity.apply(state, expr, write);
 
   // start the recursion!
-  dereference_rec(expr, state);
+  dereference_rec(expr, state, write);
   // dereferencing may introduce new symbol_exprt
   // (like __CPROVER_memory)
   state.rename(expr, ns, field_sensitivity, goto_symex_statet::L1);

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -431,7 +431,7 @@ static void merge_names(
   }
 
   // field sensitivity: only merge on individual fields
-  if(field_sensitivity.is_divisible(dest_state, ssa))
+  if(field_sensitivityt::is_divisible(ssa))
     return;
 
   // shared variables are renamed on every access anyway, we don't need to


### PR DESCRIPTION
Here's my latest batch of suggested improvements. The cleanup immediately after a field-assignments is I think the main functional problem with the current draft. There are two problems I wanted to address but not quite sure how to yet:

1. `rewrite_with_to_field_symbols` reverses a transformation made by `symex_assign_rec` with a member expression, and reverses it in a way that I expect would break with field-sensitivity switched off. I suggest this particular `with -> member` transformation should happen within `symex_assign_rec`, and the direction (with -> member or member -> with) should be controlled by whether field sensitivity is switched on. The same might also apply to `shift_indexed_access_to_lhs`.

2. I still don't have a good answer for the various `apply` sites, though I'm a bit less worried now I've managed to eliminate one from `goto_symex_statet`. The remaining ones all cluster around symex_dereference and simplify.