### PR TITLE
Annotate missed cases in the transform functions of various domains

### DIFF
--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -538,18 +538,24 @@ void custom_bitvector_domaint::transform(
 
   case CATCH:
   case THROW:
+    DATA_INVARIANT(false, "Exceptions must be removed before analysis");
+    break;
   case RETURN:
-  case ATOMIC_BEGIN:
-  case ATOMIC_END:
-  case END_FUNCTION:
-  case LOCATION:
-  case START_THREAD:
-  case END_THREAD:
-  case SKIP:
-  case ASSERT:
-  case ASSUME:
+    DATA_INVARIANT(false, "Returns must be removed before analysis");
+    break;
+  case ATOMIC_BEGIN:  // Ignoring is a valid over-approximation
+  case ATOMIC_END:    // Ignoring is a valid over-approximation
+  case END_FUNCTION:  // No action required
+  case LOCATION:      // No action required
+  case START_THREAD:  // Require a concurrent analysis at higher level
+  case END_THREAD:    // Require a concurrent analysis at higher level
+  case SKIP:          // No action required
+  case ASSERT:        // No action required
+  case ASSUME:        // Ignoring is a valid over-approximation
+    break;
   case INCOMPLETE_GOTO:
   case NO_INSTRUCTION_TYPE:
+    DATA_INVARIANT(false, "Only complete instructions can be analysed");
     break;
   }
 }

--- a/src/analyses/escape_analysis.cpp
+++ b/src/analyses/escape_analysis.cpp
@@ -253,21 +253,30 @@ void escape_domaint::transform(
     // This is the edge to the call site.
     break;
 
-  case GOTO:
+  case GOTO:         // Ignoring the guard is a valid over-approximation
+    break;
   case CATCH:
   case THROW:
+    DATA_INVARIANT(false, "Exceptions must be removed before analysis");
+    break;
   case RETURN:
-  case ATOMIC_BEGIN:
-  case ATOMIC_END:
-  case LOCATION:
-  case START_THREAD:
-  case END_THREAD:
-  case ASSERT:
-  case ASSUME:
-  case SKIP:
+    DATA_INVARIANT(false, "Returns must be removed before analysis");
+    break;
+  case ATOMIC_BEGIN:  // Ignoring is a valid over-approximation
+  case ATOMIC_END:    // Ignoring is a valid over-approximation
+  case LOCATION:      // No action required
+  case START_THREAD:  // Require a concurrent analysis at higher level
+  case END_THREAD:    // Require a concurrent analysis at higher level
+  case ASSERT:        // No action required
+  case ASSUME:        // Ignoring is a valid over-approximation
+  case SKIP:          // No action required
+    break;
   case OTHER:
+    DATA_INVARIANT(false, "Unclear what is a safe over-approximation of OTHER");
+    break;
   case INCOMPLETE_GOTO:
   case NO_INSTRUCTION_TYPE:
+    DATA_INVARIANT(false, "Only complete instructions can be analysed");
     break;
   }
 }

--- a/src/analyses/global_may_alias.cpp
+++ b/src/analyses/global_may_alias.cpp
@@ -129,23 +129,32 @@ void global_may_alias_domaint::transform(
     break;
   }
 
-  case FUNCTION_CALL:
-  case GOTO:
+  case FUNCTION_CALL:// Probably safe
+  case GOTO:         // Ignoring the guard is a valid over-approximation
+    break;
   case CATCH:
   case THROW:
+    DATA_INVARIANT(false, "Exceptions must be removed before analysis");
+    break;
   case RETURN:
-  case ATOMIC_BEGIN:
-  case ATOMIC_END:
-  case LOCATION:
-  case START_THREAD:
-  case END_THREAD:
-  case ASSERT:
-  case ASSUME:
-  case SKIP:
-  case END_FUNCTION:
+    DATA_INVARIANT(false, "Returns must be removed before analysis");
+    break;
+  case ATOMIC_BEGIN:  // Ignoring is a valid over-approximation
+  case ATOMIC_END:    // Ignoring is a valid over-approximation
+  case LOCATION:      // No action required
+  case START_THREAD:  // Require a concurrent analysis at higher level
+  case END_THREAD:    // Require a concurrent analysis at higher level
+  case ASSERT:        // No action required
+  case ASSUME:        // Ignoring is a valid over-approximation
+  case SKIP:          // No action required
+  case END_FUNCTION:  // No action required
+    break;
   case OTHER:
+    DATA_INVARIANT(false, "Unclear what is a safe over-approximation of OTHER");
+    break;
   case INCOMPLETE_GOTO:
   case NO_INSTRUCTION_TYPE:
+    DATA_INVARIANT(false, "Only complete instructions can be analysed");
     break;
   }
 }

--- a/src/analyses/interval_domain.cpp
+++ b/src/analyses/interval_domain.cpp
@@ -110,18 +110,26 @@ void interval_domaint::transform(
 
   case CATCH:
   case THROW:
+    DATA_INVARIANT(false, "Exceptions must be removed before analysis");
+    break;
   case RETURN:
-  case ATOMIC_BEGIN:
-  case ATOMIC_END:
-  case END_FUNCTION:
-  case START_THREAD:
-  case END_THREAD:
-  case ASSERT:
-  case LOCATION:
-  case SKIP:
+    DATA_INVARIANT(false, "Returns must be removed before analysis");
+    break;
+  case ATOMIC_BEGIN:  // Ignoring is a valid over-approximation
+  case ATOMIC_END:    // Ignoring is a valid over-approximation
+  case END_FUNCTION:  // No action required
+  case START_THREAD:  // Require a concurrent analysis at higher level
+  case END_THREAD:    // Require a concurrent analysis at higher level
+  case ASSERT:        // No action required
+  case LOCATION:      // No action required
+  case SKIP:          // No action required
+    break;
   case OTHER:
+    DATA_INVARIANT(false, "Unclear what is a safe over-approximation of OTHER");
+    break;
   case INCOMPLETE_GOTO:
   case NO_INSTRUCTION_TYPE:
+    DATA_INVARIANT(false, "Only complete instructions can be analysed");
     break;
   }
 }

--- a/src/analyses/invariant_set_domain.cpp
+++ b/src/analyses/invariant_set_domain.cpp
@@ -79,16 +79,19 @@ void invariant_set_domaint::transform(
 
   case CATCH:
   case THROW:
-  case DEAD:
-  case ATOMIC_BEGIN:
-  case ATOMIC_END:
-  case END_FUNCTION:
-  case LOCATION:
-  case END_THREAD:
-  case SKIP:
+    DATA_INVARIANT(false, "Exceptions must be removed before analysis");
+    break;
+  case DEAD:          // No action required
+  case ATOMIC_BEGIN:  // Ignoring is a valid over-approximation
+  case ATOMIC_END:    // Ignoring is a valid over-approximation
+  case END_FUNCTION:  // No action required
+  case LOCATION:      // No action required
+  case END_THREAD:    // Require a concurrent analysis at higher level
+  case SKIP:          // No action required
+    break;
   case INCOMPLETE_GOTO:
   case NO_INSTRUCTION_TYPE:
-    // do nothing
+    DATA_INVARIANT(false, "Only complete instructions can be analysed");
     break;
   }
 }

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -312,20 +312,28 @@ void local_bitvector_analysist::build()
 
     case CATCH:
     case THROW:
+      DATA_INVARIANT(false, "Exceptions must be removed before analysis");
+      break;
     case RETURN:
-    case ATOMIC_BEGIN:
-    case ATOMIC_END:
-    case LOCATION:
-    case START_THREAD:
-    case END_THREAD:
-    case SKIP:
+      DATA_INVARIANT(false, "Returns must be removed before analysis");
+      break;
+    case ATOMIC_BEGIN:  // Ignoring is a valid over-approximation
+    case ATOMIC_END:    // Ignoring is a valid over-approximation
+    case LOCATION:      // No action required
+    case START_THREAD:  // Require a concurrent analysis at higher level
+    case END_THREAD:    // Require a concurrent analysis at higher level
+    case SKIP:          // No action required
+    case ASSERT:        // No action required
+    case ASSUME:        // Ignoring is a valid over-approximation
+    case GOTO:          // Ignoring the guard is a valid over-approximation
+    case END_FUNCTION:  // No action required
+      break;
     case OTHER:
-    case ASSERT:
-    case ASSUME:
-    case GOTO:
-    case END_FUNCTION:
+      DATA_INVARIANT(false, "Unclear what is a safe over-approximation of OTHER");
+      break;
     case INCOMPLETE_GOTO:
     case NO_INSTRUCTION_TYPE:
+      DATA_INVARIANT(false, "Only complete instructions can be analysed");
       break;
     }
 

--- a/src/analyses/local_cfg.cpp
+++ b/src/analyses/local_cfg.cpp
@@ -86,10 +86,14 @@ void local_cfgt::build(const goto_programt &goto_program)
     case DECL:
     case DEAD:
     case ASSIGN:
-    case INCOMPLETE_GOTO:
-    case NO_INSTRUCTION_TYPE:
       node.successors.push_back(loc_nr+1);
       break;
+
+    case INCOMPLETE_GOTO:
+    case NO_INSTRUCTION_TYPE:
+      DATA_INVARIANT(false, "Only complete instructions can be analysed");
+      break;
+
     }
   }
 }

--- a/src/analyses/local_may_alias.cpp
+++ b/src/analyses/local_may_alias.cpp
@@ -419,20 +419,28 @@ void local_may_aliast::build(const goto_functiont &goto_function)
 
     case CATCH:
     case THROW:
+      DATA_INVARIANT(false, "Exceptions must be removed before analysis");
+      break;
     case RETURN:
-    case GOTO:
-    case START_THREAD:
-    case END_THREAD:
-    case ATOMIC_BEGIN:
-    case ATOMIC_END:
-    case LOCATION:
-    case SKIP:
-    case END_FUNCTION:
+      DATA_INVARIANT(false, "Returns must be removed before analysis");
+      break;
+    case GOTO:          // Ignoring the guard is a valid over-approximation
+    case START_THREAD:  // Require a concurrent analysis at higher level
+    case END_THREAD:    // Require a concurrent analysis at higher level
+    case ATOMIC_BEGIN:  // Ignoring is a valid over-approximation
+    case ATOMIC_END:    // Ignoring is a valid over-approximation
+    case LOCATION:      // No action required
+    case SKIP:          // No action required
+    case END_FUNCTION:  // No action required
+    case ASSERT:        // No action required
+    case ASSUME:        // Ignoring is a valid over-approximation
+      break;
     case OTHER:
-    case ASSERT:
-    case ASSUME:
+      DATA_INVARIANT(false, "Unclear what is a safe over-approximation of OTHER");
+      break;
     case INCOMPLETE_GOTO:
     case NO_INSTRUCTION_TYPE:
+      DATA_INVARIANT(false, "Only complete instructions can be analysed");
       break;
     }
 

--- a/src/analyses/uncaught_exceptions_analysis.cpp
+++ b/src/analyses/uncaught_exceptions_analysis.cpp
@@ -125,23 +125,30 @@ void uncaught_exceptions_domaint::transform(
     join(uea.exceptions_map[function_name]);
     break;
   }
-  case DECL:
-  case DEAD:
-  case ASSIGN:
+  case DECL:          // Safe to ignore in this context
+  case DEAD:          // Safe to ignore in this context
+  case ASSIGN:        // Safe to ignore in this context
+    break;
   case RETURN:
-  case GOTO:
-  case ATOMIC_BEGIN:
-  case ATOMIC_END:
-  case START_THREAD:
-  case END_THREAD:
-  case END_FUNCTION:
-  case ASSERT:
-  case ASSUME:
-  case LOCATION:
-  case SKIP:
+    DATA_INVARIANT(false, "Returns must be removed before analysis");
+    break;
+  case GOTO:          // Ignoring the guard is a valid over-approximation
+  case ATOMIC_BEGIN:  // Ignoring is a valid over-approximation
+  case ATOMIC_END:    // Ignoring is a valid over-approximation
+  case START_THREAD:  // Require a concurrent analysis at higher level
+  case END_THREAD:    // Require a concurrent analysis at higher level
+  case END_FUNCTION:  // No action required
+  case ASSERT:        // No action required
+  case ASSUME:        // Ignoring is a valid over-approximation
+  case LOCATION:      // No action required
+  case SKIP:          // No action required
+    break;
   case OTHER:
+    DATA_INVARIANT(false, "Unclear what is a safe over-approximation of OTHER");
+    break;
   case INCOMPLETE_GOTO:
   case NO_INSTRUCTION_TYPE:
+    DATA_INVARIANT(false, "Only complete instructions can be analysed");
     break;
   }
 }


### PR DESCRIPTION
There are a number of reasons why instruction types were left out of
these case statements :

1. Ignoring this instruction is generally a valid overapproximation.
2. Ignoring this instruction is a valid overapproximation for this
   domain.
3. The instruction is assumed to not be present due to preceeding
   passes.
4. The instruction should never appear in any valid goto program.
5. The instruction is newer than the analysis code and was forgotten.

This patch tries to correctly document which of these apply.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
