### PR TITLE
Add and use value_sett::erase_symbol

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1665,3 +1665,45 @@ void value_sett::erase_values_from_entry(
     entry.object_map.write().erase(key_to_erase);
   }
 }
+
+void value_sett::erase_struct_union_symbol(
+  const struct_union_typet &struct_union_type,
+  const std::string &erase_prefix,
+  const namespacet &ns)
+{
+  for(const auto &c : struct_union_type.components())
+  {
+    const typet &subtype = c.type();
+    const irep_idt &name = c.get_name();
+
+    // ignore methods and padding
+    if(subtype.id() == ID_code || c.get_is_padding())
+      continue;
+
+    erase_symbol_rec(subtype, erase_prefix + "." + id2string(name), ns);
+  }
+}
+
+void value_sett::erase_symbol_rec(
+  const typet &type,
+  const std::string &erase_prefix,
+  const namespacet &ns)
+{
+  if(type.id() == ID_struct_tag)
+    erase_struct_union_symbol(
+      ns.follow_tag(to_struct_tag_type(type)), erase_prefix, ns);
+  else if(type.id() == ID_union_tag)
+    erase_struct_union_symbol(
+      ns.follow_tag(to_union_tag_type(type)), erase_prefix, ns);
+  else if(type.id() == ID_array)
+    erase_symbol_rec(type.subtype(), erase_prefix + "[]", ns);
+  else
+    values.erase(erase_prefix);
+}
+
+void value_sett::erase_symbol(
+  const symbol_exprt &symbol_expr, const namespacet &ns)
+{
+  erase_symbol_rec(
+    symbol_expr.type(), id2string(symbol_expr.get_identifier()), ns);
+}

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -504,6 +504,9 @@ public:
     entryt &entry,
     const std::unordered_set<exprt, irep_hash> &values_to_erase);
 
+  void erase_symbol(
+    const symbol_exprt &symbol_expr, const namespacet &ns);
+
 protected:
   /// Reads the set of objects pointed to by `expr`, including making
   /// recursive lookups for dereference operations etc.
@@ -537,6 +540,16 @@ protected:
   void dereference_rec(
     const exprt &src,
     exprt &dest) const;
+
+  void erase_symbol_rec(
+    const typet &type,
+    const std::string &erase_prefix,
+    const namespacet &ns);
+
+  void erase_struct_union_symbol(
+    const struct_union_typet &struct_union_type,
+    const std::string &erase_prefix,
+    const namespacet &ns);
 
   // Subclass customisation points:
 


### PR DESCRIPTION
Even when we've got `value_sett` backed by `sharing_mapt`, this is surely both cheaper than and a little more elegant than taking a copy and then computing a delta? It also resolves what I think is the last outstanding issue and means we can merge field-sensitivity without tying it to `sharing_mapt`